### PR TITLE
dashed gray wrapper for the signature input

### DIFF
--- a/src/resources/views/fields/signature.blade.php
+++ b/src/resources/views/fields/signature.blade.php
@@ -71,8 +71,7 @@
                 -webkit-user-select: none;
                 -ms-user-select: none;
                 user-select: none;
-                border: 1px solid #F5F5F5;
-                border-bottom: 1px solid black;
+                border: 1px dashed rgba(0,40,100,.12);
             }
             .signature-pad {
                 position: absolute;


### PR DESCRIPTION
Opinionated change, I think a dashed grey border looks a little better, and is more in line with the rest of the Backpack fields. With or without this, this is a great field type 😄 Good job @iMokhles !

Here's the difference:
![Screenshot 2020-07-06 at 11 25 10](https://user-images.githubusercontent.com/1032474/86572596-d1cd5980-bf7b-11ea-9434-cd67e399ed0b.png)
